### PR TITLE
Controlled term search is "contains" instead of "startsWith"

### DIFF
--- a/src/app/modules/input-types/components/cedar-input-controlled/cedar-input-controlled.component.ts
+++ b/src/app/modules/input-types/components/cedar-input-controlled/cedar-input-controlled.component.ts
@@ -102,7 +102,7 @@ export class CedarInputControlledComponent extends CedarUIComponent implements O
           return null;
         } else if (response.collection) {
           return response.collection.filter((option) => {
-            return option.prefLabel.toLowerCase().indexOf(val.toLowerCase()) === 0;
+            return option.prefLabel.toLowerCase().indexOf(val.toLowerCase()) >= 0;
           });
         } else {
           if (!val) {


### PR DESCRIPTION
The backend (terminology server) returned the proper list, which was narrowed on the client with indexOf() === 0.
This is why the search did not work properly.